### PR TITLE
Changed osdc website

### DIFF
--- a/telegram-bot/main.go
+++ b/telegram-bot/main.go
@@ -24,7 +24,7 @@ func telegram(ID int64) {
 }
 
 func website(ID int64) {
-	bot.Send(tbot.NewMessage(ID, "https://osdc.surge.sh"))
+	bot.Send(tbot.NewMessage(ID, "https://osdc.netlify.com"))
 }
 
 func blog(ID int64) {


### PR DESCRIPTION
OSDC's website has been deployed now on netlify. Thread - https://github.com/osdc/osdc.github.io/pull/47. 

Thus, changed the website link in the bot. PTAL. Thanks.